### PR TITLE
Add type:module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
 	"name": "skinview-utils",
 	"version": "0.2.0",
 	"description": "Utilities for working with Minecraft skins",
+	"type": "module",
 	"main": "index.js",
-	"module": "index.js",
 	"scripts": {
 		"build": "tsc -p .",
 		"lint": "eslint . --ext .ts",


### PR DESCRIPTION
See: https://nodejs.org/api/esm.html#esm_package_json_main

Note that skinview-utils would be importable only via ES6 `import`.