### PR TITLE
Add attribute `willReadFrequently` to all calls to `getContext`

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -112,7 +112,7 @@ export function loadSkinToCanvas(canvas: TextureCanvas, image: TextureSource): v
 		}
 	}
 
-	const context = canvas.getContext("2d") as CanvasContext;
+	const context = canvas.getContext("2d", { willReadFrequently: true }) as CanvasContext;
 	if (isOldFormat) {
 		const sideLength = image.width;
 		canvas.width = sideLength;
@@ -150,7 +150,7 @@ export function loadCapeToCanvas(canvas: TextureCanvas, image: TextureSource): v
 	canvas.width = 64 * scale;
 	canvas.height = 32 * scale;
 
-	const context = canvas.getContext("2d") as CanvasContext;
+	const context = canvas.getContext("2d", { willReadFrequently: true }) as CanvasContext;
 	context.clearRect(0, 0, canvas.width, canvas.height);
 	context.drawImage(image, 0, 0, image.width, image.height);
 }
@@ -233,7 +233,7 @@ export function inferModelType(canvas: TextureCanvas): ModelType {
 	// If the 4 areas are all black or all white, the skin is also considered as slim.
 
 	const scale = computeSkinScale(canvas.width);
-	const context = canvas.getContext("2d") as CanvasContext;
+	const context = canvas.getContext("2d", { willReadFrequently: true }) as CanvasContext;
 	const checkTransparency = (x: number, y: number, w: number, h: number): boolean =>
 		hasTransparency(context, x * scale, y * scale, w * scale, h * scale);
 	const checkBlack = (x: number, y: number, w: number, h: number): boolean =>
@@ -275,7 +275,7 @@ export function loadEarsToCanvas(canvas: TextureCanvas, image: TextureSource): v
 	canvas.width = 14 * scale;
 	canvas.height = 7 * scale;
 
-	const context = canvas.getContext("2d") as CanvasContext;
+	const context = canvas.getContext("2d", { willReadFrequently: true }) as CanvasContext;
 	context.clearRect(0, 0, canvas.width, canvas.height);
 	context.drawImage(image, 0, 0, image.width, image.height);
 }
@@ -290,7 +290,7 @@ export function loadEarsToCanvasFromSkin(canvas: TextureCanvas, image: TextureSo
 	const h = 7 * scale;
 	canvas.width = w;
 	canvas.height = h;
-	const context = canvas.getContext("2d") as CanvasContext;
+	const context = canvas.getContext("2d", { willReadFrequently: true }) as CanvasContext;
 	context.clearRect(0, 0, w, h);
 	context.drawImage(image, 24 * scale, 0, w, h, 0, 0, w, h);
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -43,7 +43,9 @@ describe("detect model of texture", () => {
 
 describe("process skin texture", () => {
 	const expectTransparent = (canvas: HTMLCanvasElement, x0: number, y0: number, w: number, h: number) => {
-		const data = canvas.getContext("2d")!.getImageData(x0, y0, w, h).data;
+		const ctx = canvas.getContext("2d", { willReadFrequently: true })
+
+		const data = ctx!.getImageData(x0, y0, w, h).data;
 		for (let x = 0; x < w; x++) {
 			for (let y = 0; y < h; y++) {
 				expect(data[(y * h + x) * 4 + 3], `pixel (${x0 + x}, ${y0 + y})`).to.equal(0);


### PR DESCRIPTION
To address the downstream issue https://github.com/bs-community/skinview3d/issues/125

This change will get rid of the the console warnings about the missing attribute once it's published and updated in the other project.

Although according to MDN it's not supported on safari but I saw no issues in my testing with the package linked locally.

![image](https://user-images.githubusercontent.com/996134/198832101-5ec6bea1-452b-4c28-8479-41690dd5e8f4.png)

More info 
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
- https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently
- https://github.com/fserb/canvas2D/blob/master/spec/will-read-frequently.md